### PR TITLE
delete nd/conf.js from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-nd/conf.*
 pages/.dev
 !nd/conf.sample.js
 firebase/functions/env.json


### PR DESCRIPTION
nd/conf.js is a file that does not contain a private key. So I don't think it's necessary to add it to gitignore.
If this is added to gitignore, auto-deploy to vercel won't work.